### PR TITLE
Update grain.py

### DIFF
--- a/aimsgb/grain.py
+++ b/aimsgb/grain.py
@@ -140,10 +140,9 @@ class Grain(Structure):
             new_layers.append(sorted(tmp))
         return new_layers
 
-    def get_orthogonal_grain(self):
+    def set_orthogonal_grain(self):
         a, b, c = self.lattice.abc
-        new_latt = Lattice.orthorhombic(a, b, c)
-        return Structure(new_latt, self.species, self.frac_coords)
+        self.lattice = Lattice.orthorhombic(a, b, c)
 
     def build_grains(self, csl, gb_direction, uc_a=1, uc_b=1):
         """
@@ -170,8 +169,8 @@ class Grain(Structure):
             #               "The periodicity of the grain is most likely broken. "
             #               "We suggest user to build a very big supercell in "
             #               "order to minimize this effect.")
-            grain_a = grain_a.get_orthogonal_grain()
-            # grain_b = grain_b.get_orthogonal_grain()
+            grain_a.set_orthogonal_grain()
+            # grain_b = grain_b.set_orthogonal_grain()
 
         temp_a = grain_a.copy()
         scale_vector = [1, 1]


### PR DESCRIPTION
The current `get_orthogonal_grain` returns a pymatgen Structure object instead of an aimsgb Grain object. Consequently, [`build_gb()`](https://github.com/ksyang2013/aimsgb/blob/master/aimsgb/grain_bound.py#L517) does not work when using e.g. `delete_layer=...`, because this is only an attribute of a Grain and not a Structure (the error would then occur [here](https://github.com/ksyang2013/aimsgb/blob/master/aimsgb/grain_bound.py#L551)).

I renamed the get into a set, but this can of course be reversed.