### PR TITLE
replace `direction` by `axis` in `np.concatenate`

### DIFF
--- a/aimsgb/grain.py
+++ b/aimsgb/grain.py
@@ -128,7 +128,7 @@ class Grain(Structure):
         new_lat = Lattice(self.lattice.matrix * np.array(l_vector)[:, None])
 
         layers.pop(l1)
-        sites = reduce(lambda x, y: np.concatenate((x, y), direction=0), layers)
+        sites = reduce(lambda x, y: np.concatenate((x, y), axis=0), layers)
         new_sites = []
         l_dist = 0 if bt == "t" else l_dist
         l_vector = [0, 0]


### PR DESCRIPTION
To be honest I don't know what it exactly does, but since `direction` does not exist in `np.concatenate` (which also raises an error) and `axis` sound close enough, I suggest this change.